### PR TITLE
fix: fix android core version in plugin gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,7 +38,7 @@ android {
 }
 
 dependencies {
-    implementation "androidx.core:core-ktx:+"
+    implementation "androidx.core:core-ktx:1.7.0"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }
 


### PR DESCRIPTION
fix: fix android core version in plugin gradle fix #57 