### PR TITLE
Prevent crash if image(s) removed from gallery on some android devices

### DIFF
--- a/android/src/main/java/com/flutter/moum/screenshot_callback/ScreenshotDetector.kt
+++ b/android/src/main/java/com/flutter/moum/screenshot_callback/ScreenshotDetector.kt
@@ -33,10 +33,14 @@ class ScreenshotDetector(private val context: Context,
     }
 
     private fun queryScreenshots(uri: Uri): List<String> {
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            queryRelativeDataColumn(uri)
-        } else {
-            queryDataColumn(uri)
+        return try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                queryRelativeDataColumn(uri)
+            } else {
+                queryDataColumn(uri)
+            }
+        }  catch (e:Exception){
+            listOf()
         }
     }
 


### PR DESCRIPTION
fix: on certain android devices. when remove image(s) from gallery context.contentResolver.query() will throw "java.lang.IllegalStateException: Unknown URL: content://media/ is hidden API"

this case(s) mostly happened on Huawei devices