### PR TITLE
add read media images permission for Android 13 or higher

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -5,4 +5,5 @@
         ></application>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
 </manifest>


### PR DESCRIPTION
at Android 13 or higher, we must include new permission.

> If your app targets Android 13, you must request one or more new permissions instead of the READ_EXTERNAL_STORAGE and WRITE_EXTERNAL_STORAGE permissions.

[stack overflow thread](https://stackoverflow.com/questions/72948052/android-13-read-external-storage-permission-still-usable)

proof : https://www.loom.com/share/4b4737d98d8440848dfd396725d126f1