### PR TITLE
Fix NullPointerException in handler callback

### DIFF
--- a/android/src/main/java/com/flutter/moum/screenshot_callback/ScreenshotCallbackPlugin.java
+++ b/android/src/main/java/com/flutter/moum/screenshot_callback/ScreenshotCallbackPlugin.java
@@ -61,7 +61,9 @@ public class ScreenshotCallbackPlugin implements MethodCallHandler, FlutterPlugi
                         handler.post(new Runnable() {
                             @Override
                             public void run() {
-                                channel.invokeMethod("onCallback", null);
+                                if(channel != null) {
+                                    channel.invokeMethod("onCallback", null);
+                                }
                             }
                         });
                     }


### PR DESCRIPTION
On our production app, we encountered this issue:
```
Fatal Exception: java.lang.NullPointerException: Attempt to invoke virtual method 'void io.flutter.plugin.common.MethodChannel.invokeMethod(java.lang.String, java.lang.Object)' on a null object reference
       at com.flutter.moum.screenshot_callback.ScreenshotCallbackPlugin$1$1.run(ScreenshotCallbackPlugin.java:64)
       at android.os.Handler.handleCallback(Handler.java:942)
       at android.os.Handler.dispatchMessage(Handler.java:99)
       at android.os.Looper.loopOnce(Looper.java:201)
       at android.os.Looper.loop(Looper.java:288)
       at android.app.ActivityThread.main(ActivityThread.java:8061)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:703)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:923)
```
This PR fixes the above issue by making sure channel is non null in the handler callback.