### PR TITLE
Update install link on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 ### Import the package
 
-To use this plugin, follow the [**plugin installation instructions**](https://pub.dev/packages/screenshot_callback#-installing-tab-).
+To use this plugin, follow the [**plugin installation instructions**](https://pub.dev/packages/screenshot_callback#install).
 
 ### Use the plugin
 


### PR DESCRIPTION
The current install link in the README.md file doesn't lead to the pub.dev install tab. 

This PR fixes the issue by leading the install link to the right pub.dev install tab. 